### PR TITLE
Specify exclude paths for codacy

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,2 +1,3 @@
 exclude_paths:
- - '**/tests/**'
+  - tests/**
+  - .github/**

--- a/typed_json_dataclass/typed_json_dataclass.py
+++ b/typed_json_dataclass/typed_json_dataclass.py
@@ -162,7 +162,8 @@ class TypedJsonMixin:
         all elements in the list are uniform
         """
         # typing.List[type] will have __args__
-        if type(actual_value) is list and hasattr(expected_type, '__args__'):
+        if isinstance(actual_value, list) and \
+           hasattr(expected_type, '__args__'):
             nested_type = expected_type.__args__[0]
             if isinstance(nested_type, typing.ForwardRef):
                 # Strip out ForwardRef(' and ') as a hack for getting the
@@ -177,7 +178,7 @@ class TypedJsonMixin:
                 self._validate_list_types(v, nested_type) for v in actual_value
             )
         else:
-            return type(actual_value) is expected_type
+            return isinstance(actual_value, expected_type)
 
     @classmethod
     def from_dict(cls, raw_dict):


### PR DESCRIPTION
Codacy doesn't like the use of assert, but we use that in the tests
because pytest re-writes how assert works.
