### PR TITLE
Create flag for auto mapping camel and snake case

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ def to_json(self, *, keep_none=False):
 
 ## Examples
 
-Converting your dataclass to a JSON serializable format:
+### Converting your dataclass to a JSON serializable format
 ```python
 from typing import List
 from dataclasses import dataclass
@@ -96,6 +96,7 @@ family = Family(people=[bob, alice])
 print(family.to_json())
 # => {"people": [{"name": "Bob", "age": 24}, {"name": "Alice", "age": 32}]}
 ```
+
 
 If your data doesn't match the type definitions, you'll get a helpful error:
 ```python
@@ -131,6 +132,29 @@ request_data_as_dict = {
 alice = Person.from_dict(request_data_as_dict)
 # => TypeError: Person.age is expected to be <class 'int'>, but value 32 with type <class 'str'> was found instead
 ```
+
+### Setting a mapping_mode for auto mapping
+```python
+from dataclasses import dataclass
+from typed_json_dataclass import TypedJsonMixin, MappingMode
+
+@dataclass
+class Person(TypedJsonMixin):
+    person_name: str
+    person_age: int
+
+request_data_as_dict = {
+    'personName': 'Alice',
+    'personAge': 32
+}
+
+alice = Person.from_dict(request_data_as_dict, mapping_mode=MappingMode.SnakeCase)
+# => Person(person_name='Alice', person_age=32)
+```
+
+This mapping mode is useful for when you get requests that have the JSON in a
+camel case format, but you want your objects to be snake case and stay PEP8
+compliant.
 
 ## Changelog
 

--- a/tests/test_mapping_configurations.py
+++ b/tests/test_mapping_configurations.py
@@ -1,0 +1,164 @@
+from dataclasses import dataclass
+
+import pytest
+from typed_json_dataclass import TypedJsonMixin, MappingMode
+
+
+@dataclass
+class SnakeCaseObjects(TypedJsonMixin):
+    object_id: str
+
+
+@dataclass
+class CamelCaseObjects(TypedJsonMixin):
+    objectId: str
+
+
+@dataclass
+class ChildObject(TypedJsonMixin):
+    objectId: str
+
+
+@dataclass
+class ParentObject(TypedJsonMixin):
+    objectId: str
+    child: ChildObject
+
+
+def test_mapping_from_dict_to_snake_case():
+    camel_case_object = {
+        'objectId': 'asdf'
+    }
+
+    expected_object = SnakeCaseObjects('asdf')
+    assert SnakeCaseObjects.from_dict(
+            camel_case_object,
+            mapping_mode=MappingMode.SnakeCase) == expected_object
+
+
+def test_mapping_from_dict_to_camel_case():
+
+    snake_case_json = {
+        'object_id': 'asdf'
+    }
+
+    expected_object = CamelCaseObjects('asdf')
+    assert CamelCaseObjects.from_dict(
+            snake_case_json,
+            mapping_mode=MappingMode.CamelCase) == expected_object
+
+
+def test_mapping_from_json_to_snake_case():
+    camel_case_json = """
+    {
+        "objectId": "asdf"
+    }
+    """
+
+    expected_object = SnakeCaseObjects('asdf')
+    assert SnakeCaseObjects.from_json(
+            camel_case_json,
+            mapping_mode=MappingMode.SnakeCase) == expected_object
+
+
+def test_mapping_from_json_to_camel_case():
+    snake_case_json = """
+    {
+        "object_id": "asdf"
+    }
+    """
+
+    expected_object = CamelCaseObjects('asdf')
+    assert CamelCaseObjects.from_json(
+            snake_case_json,
+            mapping_mode=MappingMode.CamelCase) == expected_object
+
+
+def test_mapping_to_camel_case_dict_from_snake_case():
+    expected = {
+        'object_id': 'asdf'
+    }
+
+    target = CamelCaseObjects('asdf')
+    actual = target.to_dict(mapping_mode=MappingMode.SnakeCase)
+    assert expected == actual
+
+
+def test_mapping_to_snake_case_dict_from_camel_case():
+
+    expected = {
+        'objectId': 'asdf'
+    }
+
+    target = SnakeCaseObjects('asdf')
+    actual = target.to_dict(mapping_mode=MappingMode.CamelCase)
+    assert expected == actual
+
+
+def test_from_json_with_invalid_mapping_mode():
+    with pytest.raises(ValueError) as e_info:
+        SnakeCaseObjects.from_json('{"object_id": ""}', mapping_mode='Invalid')
+    assert str(e_info.value) == 'Invalid mapping mode'
+
+
+def test_to_json_with_invalid_mapping_mode():
+    with pytest.raises(ValueError) as e_info:
+        SnakeCaseObjects('asdf').to_json(mapping_mode='Invalid')
+    assert str(e_info.value) == 'Invalid mapping mode'
+
+
+def test_from_dict_with_invalid_mapping_mode():
+    with pytest.raises(ValueError) as e_info:
+        SnakeCaseObjects.from_dict({'object_id': ''}, mapping_mode='Invalid')
+    assert str(e_info.value) == 'Invalid mapping mode'
+
+
+def test_to_dict_with_invalid_mapping_mode():
+    with pytest.raises(ValueError) as e_info:
+        SnakeCaseObjects('asdf').to_dict(mapping_mode='Invalid')
+    assert str(e_info.value) == 'Invalid mapping mode'
+
+
+def test_recursive_from_dict_mapping():
+    target = {
+        'object_id': 'asdf',
+        'child': {
+            'object_id': 'fdsa'
+        }
+    }
+    expected = ParentObject('asdf', ChildObject('fdsa'))
+    actual = ParentObject.from_dict(target, mapping_mode=MappingMode.CamelCase)
+    assert expected == actual
+
+
+def test_recursive_to_dict_mapping():
+    expected = {
+        'object_id': 'asdf',
+        'child': {
+            'object_id': 'fdsa'
+        }
+    }
+    target = ParentObject('asdf', ChildObject('fdsa'))
+    actual = target.to_dict(mapping_mode=MappingMode.SnakeCase)
+    assert expected == actual
+
+
+def test_recursive_from_json_mapping():
+    target = """
+    {
+        "object_id": "asdf",
+        "child": {
+            "object_id": "fdsa"
+        }
+    }
+    """
+    expected = ParentObject('asdf', ChildObject('fdsa'))
+    actual = ParentObject.from_json(target, mapping_mode=MappingMode.CamelCase)
+    assert expected == actual
+
+
+def test_recursive_to_json_mapping():
+    expected = """{"object_id": "asdf", "child": {"object_id": "fdsa"}}"""
+    target = ParentObject('asdf', ChildObject('fdsa'))
+    actual = target.to_json(mapping_mode=MappingMode.SnakeCase)
+    assert expected == actual

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,28 @@
+import pytest
+from typed_json_dataclass.utils import (
+    to_snake as to_s,
+    to_camel as to_c,
+)
+
+
+@pytest.mark.parametrize('target, expected', [
+    ('hereIsSomethingInCamelCase', 'here_is_something_in_camel_case'),
+    ('hereIsSomeThingInCamelCase', 'here_is_some_thing_in_camel_case'),
+    ('_here_is_something_in_snake_case', '_here_is_something_in_snake_case'),
+    ('HereIsSomethingInTitleCase', 'here_is_something_in_title_case')
+])
+def test_to_snake_case(target, expected):
+    actual = to_s(target)
+    assert expected == actual
+
+
+@pytest.mark.parametrize('target, expected', [
+    ('here_is_something_in_camel_case', 'hereIsSomethingInCamelCase'),
+    ('_here_is_something_in_camel_case', 'hereIsSomethingInCamelCase'),
+    ('___here_is_something_in_camel_case', 'hereIsSomethingInCamelCase'),
+    ('___here___is_something_in_camel__case', 'hereIsSomethingInCamelCase'),
+    ('HereIsSomethingInTitleCase', 'hereIsSomethingInTitleCase')
+])
+def test_to_camel_case(target, expected):
+    actual = to_c(target)
+    assert expected == actual

--- a/typed_json_dataclass/__init__.py
+++ b/typed_json_dataclass/__init__.py
@@ -1,3 +1,10 @@
-from typed_json_dataclass.typed_json_dataclass import TypedJsonMixin  # noqa
+from typed_json_dataclass.typed_json_dataclass import (
+    TypedJsonMixin,
+    MappingMode,
+)
 
 __version__ = '0.1.1'
+__all__ = [
+    'TypedJsonMixin',
+    'MappingMode',
+]

--- a/typed_json_dataclass/utils.py
+++ b/typed_json_dataclass/utils.py
@@ -1,0 +1,44 @@
+def to_snake(string_to_convert: str):
+    converted = ''
+    for i, c in enumerate(string_to_convert):
+        if c == c.lower():
+            converted += c
+        else:
+            if 0 < i:
+                converted += '_'
+            converted += c.lower()
+    return converted
+
+
+def to_camel(string_to_convert: str):
+    converted = ''
+    next_is_capital = False
+    for i, c in enumerate(string_to_convert):
+        if c == '_':
+            next_is_capital = i != 0 and converted != ''
+            continue
+
+        if c == c.upper():
+            next_is_capital = True
+
+        if i == 0:
+            converted += c.lower()
+            next_is_capital = False
+            continue
+
+        if next_is_capital:
+            converted += c.upper()
+            next_is_capital = False
+        else:
+            converted += c.lower()
+
+    return converted
+
+
+def recursive_rename(raw_dict, format_method):
+    renamed_dict = {}
+    for k, v in raw_dict.items():
+        if isinstance(v, dict):
+            v = recursive_rename(v, format_method)
+        renamed_dict[format_method(k)] = v
+    return renamed_dict


### PR DESCRIPTION
JSON tends to have camel cased keys, but Python variables tend to be
snake cased. This meant that the normal use case for this library was to
have an object defined to receive the json requests and validate them,
and then you'd have to manually map everything from the camel casing, to
the exact same objects but with snake casing.

This change adds a new MappingMode keyword argument to the from/to
json/dict methods that are added by the mixin. This means that you could
have your actual dataclass defined with snake case variables, as is the
norm in Python code, but you can call
`from_dict(dct, mapping_mode=MappingMode.SnakeCase)` which will take all of
the camel case keys in your json and convert them to snake case, before
the rest of the dataclass is instantiated and type checked.