### PR TITLE
Version bump to release 0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ compliant.
 
 ## Changelog
 
+0.1.2 - Wed, 2019-05-29
+* Upgrade urllib3 to address CVE-2019-11324
+
 0.1.1 - Sun, 2018-12-30
 * Correct some lazy tests
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools.command.install import install
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-VERSION = '0.1.1'
+VERSION = '0.1.2'
 about = {'version': VERSION}
 
 with open(

--- a/typed_json_dataclass/__init__.py
+++ b/typed_json_dataclass/__init__.py
@@ -3,7 +3,7 @@ from typed_json_dataclass.typed_json_dataclass import (
     MappingMode,
 )
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 __all__ = [
     'TypedJsonMixin',
     'MappingMode',


### PR DESCRIPTION
This commit is just so that we can release a version of this library
that has an updated version of urllib3, that patches CVE-2019-11324.
