### PR TITLE
Handle init-only variables more elegantly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "typed-json-dataclass"
-version = "1.0.0"
+version = "1.1.0"
 description = "Make your dataclasses automatically validate their types"
 authors = ["Aaron <AaronBatilo@gmail.com>"]
 license = "MIT"

--- a/tests/test_issue_8.py
+++ b/tests/test_issue_8.py
@@ -1,6 +1,6 @@
 """Tests for https://github.com/abatilo/typed-json-dataclass/issues/8"""
 
-from dataclasses import dataclass, InitVar
+from dataclasses import InitVar, dataclass
 
 import pytest
 

--- a/tests/test_issue_8.py
+++ b/tests/test_issue_8.py
@@ -73,3 +73,12 @@ def test_that_dataclass_with_init_var_from_dict_leads_to_typeerror() -> None:
 
     with pytest.raises(TypeError, match='init-only variables'):
         DataclassWithInitVar.from_dict(raw_dict)
+
+
+def test_init_var_dc_from_dict_no_error_when_default_value_provided() -> None:
+    raw_dict = {'a': 3, 'b': 'f'}
+
+    result = DataclassWithDefaultInitVar.from_dict(raw_dict)
+
+    assert result.a == 3
+    assert result.b == 'f'

--- a/tests/test_issue_8.py
+++ b/tests/test_issue_8.py
@@ -48,7 +48,16 @@ def test_that_dataclass_with_init_var_to_dict_leads_to_warning() -> None:
     assert result == {'a': 3, 'b': 'f'}
 
 
-def test_init_var_dc_no_warnings_when_acknowledged() -> None:
+def test_that_dataclass_with_init_var_to_json_leads_to_warning() -> None:
+    dcls = DataclassWithInitVar('foo')
+
+    with pytest.warns(UserWarning, match='init-only variables'):
+        result = dcls.to_json()
+
+    assert result == '{"a": 3, "b": "f"}'
+
+
+def test_init_var_dc_to_dict_no_warnings_when_acknowledged() -> None:
     dcls = DataclassWithInitVar('foo')
 
     with pytest.warns(None) as recorded_warnings:
@@ -58,7 +67,17 @@ def test_init_var_dc_no_warnings_when_acknowledged() -> None:
     assert result == {'a': 3, 'b': 'f'}
 
 
-def test_init_var_dc_no_warnings_when_init_var_has_default_value() -> None:
+def test_init_var_dc_to_json_no_warnings_when_acknowledged() -> None:
+    dcls = DataclassWithInitVar('foo')
+
+    with pytest.warns(None) as recorded_warnings:
+        result = dcls.to_json(warn_on_initvar=False)
+
+    assert not recorded_warnings
+    assert result == '{"a": 3, "b": "f"}'
+
+
+def test_init_var_dc_to_dict_no_warning_when_default_value_provided() -> None:
     dcls = DataclassWithDefaultInitVar('foo')
 
     with pytest.warns(None) as recorded_warnings:
@@ -68,6 +87,16 @@ def test_init_var_dc_no_warnings_when_init_var_has_default_value() -> None:
     assert result == {'a': 3, 'b': 'f'}
 
 
+def test_init_var_dc_to_json_no_warning_when_default_value_provided() -> None:
+    dcls = DataclassWithDefaultInitVar('foo')
+
+    with pytest.warns(None) as recorded_warnings:
+        result = dcls.to_json()
+
+    assert not recorded_warnings
+    assert result == '{"a": 3, "b": "f"}'
+
+
 def test_that_dataclass_with_init_var_from_dict_leads_to_typeerror() -> None:
     raw_dict = {'a': 3, 'b': 'f'}
 
@@ -75,10 +104,26 @@ def test_that_dataclass_with_init_var_from_dict_leads_to_typeerror() -> None:
         DataclassWithInitVar.from_dict(raw_dict)
 
 
+def test_that_dataclass_with_init_var_from_json_leads_to_typeerror() -> None:
+    raw_json = '{"a": 3, "b": "f"}'
+
+    with pytest.raises(TypeError, match='init-only variables'):
+        DataclassWithInitVar.from_json(raw_json)
+
+
 def test_init_var_dc_from_dict_no_error_when_default_value_provided() -> None:
     raw_dict = {'a': 3, 'b': 'f'}
 
     result = DataclassWithDefaultInitVar.from_dict(raw_dict)
+
+    assert result.a == 3
+    assert result.b == 'f'
+
+
+def test_init_var_dc_from_json_no_error_when_default_value_provided() -> None:
+    raw_json = '{"a": 3, "b": "f"}'
+
+    result = DataclassWithDefaultInitVar.from_json(raw_json)
 
     assert result.a == 3
     assert result.b == 'f'

--- a/tests/test_issue_8.py
+++ b/tests/test_issue_8.py
@@ -6,6 +6,7 @@ import pytest
 
 from typed_json_dataclass import TypedJsonMixin
 
+
 @dataclass
 class DataclassWithInitVar(TypedJsonMixin):
     init: InitVar[str]
@@ -127,3 +128,31 @@ def test_init_var_dc_from_json_no_error_when_default_value_provided() -> None:
 
     assert result.a == 3
     assert result.b == 'f'
+
+
+@dataclass
+class DataclassWithNestedInitVar(TypedJsonMixin):
+    child_dc: DataclassWithInitVar
+
+
+@dataclass
+class DataclassWithVeryNestedInitVar(TypedJsonMixin):
+    child_dc: DataclassWithNestedInitVar
+
+
+@dataclass
+class DataclassWithoutInitVar(TypedJsonMixin):
+    a: int
+    b: str
+
+
+@pytest.mark.parametrize('cls', [
+        DataclassWithInitVar,
+        DataclassWithNestedInitVar,
+        DataclassWithVeryNestedInitVar])
+def test_dc_with_init_var_in_child_should_contain_init_var(cls) -> None:
+    assert cls._contains_non_default_init_vars()
+
+
+def test_dc_without_init_var_should_not_contain_init_var() -> None:
+    assert not DataclassWithoutInitVar._contains_non_default_init_vars()

--- a/tests/test_issue_8.py
+++ b/tests/test_issue_8.py
@@ -18,6 +18,20 @@ class DataclassWithInitVar(TypedJsonMixin):
         super().__post_init__()
 
 
+@dataclass
+class DataclassWithDefaultInitVar(TypedJsonMixin):
+    init: InitVar[str] = None
+    a: int = 0
+    b: str = ''
+
+    def __post_init__(self, init: str) -> None:
+        if init is None:
+            # from_dict
+            return
+        self.a = len(init)
+        self.b = init[0]
+
+
 def test_that_instantiation_of_dataclass_with_init_var_typechecks() -> None:
     result = DataclassWithInitVar('foo')
 
@@ -31,6 +45,26 @@ def test_that_dataclass_with_init_var_to_dict_leads_to_warning() -> None:
     with pytest.warns(UserWarning, match='init-only variables'):
         result = dcls.to_dict()
 
+    assert result == {'a': 3, 'b': 'f'}
+
+
+def test_init_var_dc_no_warnings_when_acknowledged() -> None:
+    dcls = DataclassWithInitVar('foo')
+
+    with pytest.warns(None) as recorded_warnings:
+        result = dcls.to_dict(warn_on_initvar=False)
+
+    assert not recorded_warnings
+    assert result == {'a': 3, 'b': 'f'}
+
+
+def test_init_var_dc_no_warnings_when_init_var_has_default_value() -> None:
+    dcls = DataclassWithDefaultInitVar('foo')
+
+    with pytest.warns(None) as recorded_warnings:
+        result = dcls.to_dict()
+
+    assert not recorded_warnings
     assert result == {'a': 3, 'b': 'f'}
 
 

--- a/tests/test_issue_8.py
+++ b/tests/test_issue_8.py
@@ -1,0 +1,41 @@
+"""Tests for https://github.com/abatilo/typed-json-dataclass/issues/8"""
+
+from dataclasses import dataclass, InitVar
+
+import pytest
+
+from typed_json_dataclass import TypedJsonMixin
+
+@dataclass
+class DataclassWithInitVar(TypedJsonMixin):
+    init: InitVar[str]
+    a: int = 0
+    b: str = ''
+
+    def __post_init__(self, init: str) -> None:
+        self.a = len(init)
+        self.b = init[0]
+        super().__post_init__()
+
+
+def test_that_instantiation_of_dataclass_with_init_var_typechecks() -> None:
+    result = DataclassWithInitVar('foo')
+
+    assert result.a == 3
+    assert result.b == 'f'
+
+
+def test_that_dataclass_with_init_var_to_dict_leads_to_warning() -> None:
+    dcls = DataclassWithInitVar('foo')
+
+    with pytest.warns(UserWarning, match='init-only variables'):
+        result = dcls.to_dict()
+
+    assert result == {'a': 3, 'b': 'f'}
+
+
+def test_that_dataclass_with_init_var_from_dict_leads_to_typeerror() -> None:
+    raw_dict = {'a': 3, 'b': 'f'}
+
+    with pytest.raises(TypeError, match='init-only variables'):
+        DataclassWithInitVar.from_dict(raw_dict)

--- a/typed_json_dataclass/typed_json_dataclass.py
+++ b/typed_json_dataclass/typed_json_dataclass.py
@@ -250,8 +250,8 @@ class TypedJsonMixin:
 
         :keep_none: Filter keys that are None
         :mapping_mode: Format for properties
-        :warn_on_initvar: Emit a warning if a dataclass containing non-default
-                          init-only variables is converted.
+        :warn_on_initvar: Emit a warning if the instance contains non-default
+                          init-only variables.
         :returns: Returns the instantiated DTO as a dictionary
         """
         if not isinstance(mapping_mode, MappingMode):
@@ -284,8 +284,8 @@ class TypedJsonMixin:
 
         :keep_none: Filter keys that are None
         :mapping_mode: Format for properties
-        :warn_on_initvar: Emit a warning if a dataclass containing non-default
-                          init-only variables is converted.
+        :warn_on_initvar: Emit a warning if the instance contains non-default
+                          init-only variables.
         :returns: Returns the instantiated DTO as a json string
         """
         return json.dumps(self.to_dict(

--- a/typed_json_dataclass/typed_json_dataclass.py
+++ b/typed_json_dataclass/typed_json_dataclass.py
@@ -202,11 +202,12 @@ class TypedJsonMixin:
         else:
             return isinstance(actual_value, expected_type)
 
-    def _contains_non_default_init_vars(self):
+    @classmethod
+    def _contains_non_default_init_vars(cls):
         """Check whether this dataclass contains non-default init-only vars."""
         # The identify check (.. is MISSING) is fine, MISSING is a singleton
         return any(field.type == InitVar and field.default is MISSING
-                   for field in self.__dataclass_fields__.values())
+                   for field in cls.__dataclass_fields__.values())
 
     @classmethod
     def from_dict(cls, raw_dict, *, mapping_mode=MappingMode.NoMap):
@@ -219,6 +220,10 @@ class TypedJsonMixin:
 
         if not isinstance(mapping_mode, MappingMode):
             raise ValueError('Invalid mapping mode')
+
+        if cls._contains_non_default_init_vars():
+            raise TypeError('Cannot instantiate a dataclass with non-default '
+                            'init-only variables')
 
         if mapping_mode == MappingMode.NoMap:
             return cls(**raw_dict)

--- a/typed_json_dataclass/typed_json_dataclass.py
+++ b/typed_json_dataclass/typed_json_dataclass.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3.7
 import json
 import typing
-from dataclasses import asdict
+from dataclasses import asdict, fields
 from enum import Enum
 
 from typed_json_dataclass.utils import to_camel, to_snake, recursive_rename
@@ -25,7 +25,8 @@ class TypedJsonMixin:
         Based heavily on:
         https://stackoverflow.com/questions/50563546/validating-detailed-types-in-python-dataclasses
         """
-        for field_name, field_def in self.__dataclass_fields__.items():
+        for field_def in fields(self):
+            field_name = field_def.name
             field_value = getattr(self, field_name)
             actual_type = type(field_value)
 


### PR DESCRIPTION
## Proposed changes

Updates the mixin to more elegantly handle dataclasses with init-only variables, and document limitations in the README.

Concretely:
- Post-init validation of dataclasses containing init-only variables now ignores these init-only variables, which would previously lead to an uncaught exception.
- Conversion of dataclasses containing non-default init-only variables now emits a warning stating that the instance cannot be re-instantiated. These warnings can be disabled using a kw param.
- Instantiation of dataclasses containing non-default init-only variables now raises a more descriptive `TypeError`.
- Included a "Caveats" section in the README, documented the limitations with init-only variables and workarounds.

## Related issue

This fixes #8, or at least handles it more gracefully.

## Types of changes

What types of changes does your code introduce to ~sanic-swagger~ typed-json-mixin?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
  to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here
to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] gitlint passes, and my commit messages follow [best practice](https://chris.beams.io/posts/git-commit/)
- [x] flake8 passes locally with my changes
- [x] pytest passes locally with my changes, with minimum of 90% code coverage
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have updated the version numbers referenced in `setup.py` and
  `sanic_swagger/__init__.py`
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

Another workaround would be to have some sort of default singleton (`DEFAULT = object()`) and supply this as the value of a required (non-default) init-only variable, and have the user be responsible to check for and handle this default value in `__post_init__`. Then non-default init-only vars could still be used. It'd still be a workaround though, but one that is supported from within typed-json-mixin. However, I believe that would be a bit of over-engineering, and it'd be a breaking change, so it's not my call to make.
